### PR TITLE
Allow `published` to be overridden

### DIFF
--- a/mentions/models/mixins/quotable.py
+++ b/mentions/models/mixins/quotable.py
@@ -2,6 +2,7 @@ import logging
 
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
+from django.utils import timezone
 from django.db import models
 
 log = logging.getLogger()
@@ -23,7 +24,7 @@ class QuotableMixin(models.Model):
         help_text="A short excerpt from the quoted piece",
     )
 
-    published = models.DateTimeField(auto_now_add=True)
+    published = models.DateTimeField(default=timezone.now)
 
     hcard = models.ForeignKey("HCard", blank=True, null=True, on_delete=models.CASCADE)
 


### PR DESCRIPTION
I'm migrating my site over to Wagtail and using django-wm to handle webmentions. 

Whilst running the content import I noticed that all the published dates for existing webmentions were set to today, because `published` is set to `auto_now_add=True`, which [can't be overridden](https://docs.djangoproject.com/en/4.0/ref/models/fields/#django.db.models.DateField.auto_now_add). 

There's already a `created_at` field set in `MentionsBaseModel` using `auto_now_add=True`. 

This change sets `published` to `timezone.now` maintaining existing functionality but allowing the field to be overriden during an import.